### PR TITLE
Update config for our new custom domain

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ description: >- # this means to ignore newlines until "baseurl:"
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
 baseurl: "" # leave empty for local dev; override in _config_prod.yml for GitHub Pages
-url: "https://illinois-digital-service.github.io" # the base hostname & protocol for your site
+url: "https://illinoisdigitalservice.org" # the base hostname & protocol for your site
 twitter_username: jekyllrb
 github_username:  jekyll
 

--- a/_config_prod.yml
+++ b/_config_prod.yml
@@ -1,4 +1,4 @@
-# Production overrides for GitHub Pages deployment
+# Production overrides for custom domain deployment
 # Build with: jekyll build --config _config.yml,_config_prod.yml
 
-baseurl: "/ilds-website"
+baseurl: "" # Empty for custom domain (illinoisdigitalservice.org)


### PR DESCRIPTION
## What does this change?

Updates our config to reflect our new custom domain, illinoisdigitalservice.org! 

## Why is it needed?

The site won't build correctly at our new custom domain without this. 

## How to test

Unfortunately, not really possible to test before we merge. 

Once we merge, we might see the Jekyll site play nicely with our new custom domain! Noting that the D.H. team is still actively setting up DNS and the custom domain seems to be in flux, so we may not see things working right away. 