### PR TITLE
Projects page hover styles, new tab CTA, sentence case titles

### DIFF
--- a/_includes/cta-section.html
+++ b/_includes/cta-section.html
@@ -9,7 +9,7 @@
     {% endif %}
     {% if include.heading %}
       {% if include.heading_url %}
-        <h2><a href="{{ include.heading_url | relative_url }}" class="link-underline link-with-arrow" {% if include.link_color %}style="color: {{ include.link_color }}; --link-color: {{ include.link_color }};"{% endif %}><span>{{ include.heading }}</span>{% include glitch-arrow.html %}</a></h2>
+        <h2><a href="{{ include.heading_url | relative_url }}" class="link-underline link-with-arrow" {% if include.new_tab %}target="_blank" rel="noopener"{% endif %} {% if include.link_color %}style="color: {{ include.link_color }}; --link-color: {{ include.link_color }};"{% endif %}><span>{{ include.heading }}</span>{% include glitch-arrow.html %}</a></h2>
       {% else %}
         <h2>{{ include.heading }}</h2>
       {% endif %}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -969,9 +969,18 @@ main {
   transform: translateY(-0.5rem);
 }
 
+.project-card:hover .project-card-header {
+  background-color: #005870;
+}
+
+.project-card:hover .project-card-header h2 {
+  text-decoration: underline;
+}
+
 .project-card-header {
   background-color: var(--blue);
   padding: 4rem;
+  transition: background-color var(--transition);
 }
 
 .project-card-header h2 {

--- a/projects.md
+++ b/projects.md
@@ -1,12 +1,12 @@
 ---
 layout: default
-title: Our Projects | Illinois Digital Service
+title: Projects | Illinois Digital Service
 permalink: /projects/
 ---
 
 <div class="page-projects">
   {% include page-heading.html
-    title="Our Projects"
+    title="Projects"
     show_logo=true
     bg_image="/assets/images/background_images/haley-hamilton-BHZKY4Jzi_I-unsplash.jpg"
     bg_position="center"
@@ -17,7 +17,7 @@ permalink: /projects/
     <div class="container">
       <a href="https://illinoisdigitalservice.substack.com/p/sending-labor-complaints-to-the-right" target="_blank" rel="noopener" class="project-card" aria-label="Sending Labor Complaints to the Right Place (opens in new tab)">
         <div class="project-card-header">
-          <h2 aria-hidden="true">Sending Labor Complaints to the Right Place</h2>
+          <h2 aria-hidden="true">Sending labor complaints to the right place</h2>
         </div>
         <div class="project-card-body">
           <p>Illinois Digital Service has been working with the Illinois Department of Labor to improve the online "front door" for Illinoisans who need to file a labor complaint.</p>
@@ -31,7 +31,7 @@ permalink: /projects/
 
       <a href="https://docs.google.com/document/u/1/d/e/2PACX-1vQkUAQO_is5DTW3zX3K36tJGlm-NRnScPEIpFJnEayaM9yH7HW2zIruRwIjM9-2LPn_-zygjFGzHvNx/pub" target="_blank" rel="noopener" class="project-card" aria-label="Demystifying Government Hiring (opens in new tab)">
         <div class="project-card-header">
-          <h2 aria-hidden="true">Demystifying Government Hiring</h2>
+          <h2 aria-hidden="true">Demystifying government hiring</h2>
         </div>
         <div class="project-card-body">
           <p>This guide aims to demystify the process of finding and applying to tech-related roles in Illinois by providing you with knowledge and tips, synthesized from desk research and conversations with applicants and hiring managers.</p>
@@ -52,6 +52,7 @@ permalink: /projects/
   bg_color="var(--orange)"
   text_color="var(--cream)"
   link_color="var(--cream)"
+  new_tab=true
 %}
 
 {% include cta-section.html


### PR DESCRIPTION
## What does this change?

- Add blue lighten-on-hover to project card headers (AAA contrast maintained at 7.16:1)
- Add title underline on project card hover
- Open "Read more about our latest projects" CTA in new tab
- Make titles sentence case
- Revert hero logo drop shadow to original subtle values (was changed in this branch earlier then reverted back)

## Why is it needed?

- Link accessibility & style consistency

## How to test

- Locally or on the test site, view the above listed changes, run color changes through a color contrast accessibility checker

## Screenshots and/or preview build

n/a

## Accessibility and usability checks

+ Does the change affect page navigation? -> [Keyboard test](https://doit.illinois.gov/initiatives/accessibility/testing/keyboard.html)
+ Does the change affect colors or contrast? -> [Visual test](https://doit.illinois.gov/initiatives/accessibility/testing/visual.html)
